### PR TITLE
feat: Save card on enter key pressed / Remove card on esc key pressed

### DIFF
--- a/src/Component/Board/Board.js
+++ b/src/Component/Board/Board.js
@@ -3,18 +3,27 @@ import React from 'react'
 // Board :: Props -> React.Component
 export default ({
   addCard,
-  isLoading,
-  cards
+  cards,
+  cardTitle,
+  isBlankCardVisible,
+  saveCard,
+  setBlankCardTitle,
 }) =>
-  <main className="myBoard">
+  <main className="my-board">
+
+    <input
+      className={isBlankCardVisible ? "new-card" : "new-card hidden"}
+      placeholder="What needs to be done?"
+      value={cardTitle}
+      onChange={e => setBlankCardTitle(e.target.value)}
+      onKeyUp={e => e.keyCode === 13 && saveCard(e.target.value)}
+    />
+
     {cards.map((value, key) =>
       <div key={key} className="card">
         <h3 className="card-title">{value.title}</h3>
       </div>
     )}
 
-    {isLoading
-      ? <div className="board loader">We are adding a new card...</div>
-      : <button className="board add-card" onClick={addCard}>Add another card</button>
-    }
+    <button className="board add-card" onClick={addCard}>Add another card</button>
   </main>

--- a/src/Component/Board/Board.js
+++ b/src/Component/Board/Board.js
@@ -10,7 +10,6 @@ export default ({
   setBlankCardTitle,
 }) =>
   <main className="my-board">
-
     <input
       className={isBlankCardVisible ? "new-card" : "new-card hidden"}
       placeholder="What needs to be done?"

--- a/src/Component/Board/__snapshots__/index.spec.js.snap
+++ b/src/Component/Board/__snapshots__/index.spec.js.snap
@@ -2,8 +2,15 @@
 
 exports[`Component :: Board :: index checks the initial state and verify if the board is empty 1`] = `
 <main
-  className="myBoard"
+  className="my-board"
 >
+  <input
+    className="new-card hidden"
+    onChange={[Function]}
+    onKeyUp={[Function]}
+    placeholder="What needs to be done?"
+    value=""
+  />
   <button
     className="board add-card"
     onClick={[Function]}
@@ -13,17 +20,24 @@ exports[`Component :: Board :: index checks the initial state and verify if the 
 </main>
 `;
 
-exports[`Component :: Board :: index displays the cards and add "add another card button" when it is not creating any card 1`] = `
+exports[`Component :: Board :: index displays the cards when a card is added 1`] = `
 <main
-  className="myBoard"
+  className="my-board"
 >
+  <input
+    className="new-card hidden"
+    onChange={[Function]}
+    onKeyUp={[Function]}
+    placeholder="What needs to be done?"
+    value=""
+  />
   <div
     className="card"
   >
     <h3
       className="card-title"
     >
-      My test card
+      My card
     </h3>
   </div>
   <button
@@ -35,14 +49,42 @@ exports[`Component :: Board :: index displays the cards and add "add another car
 </main>
 `;
 
-exports[`Component :: Board :: index loads when a card is creating 1`] = `
+exports[`Component :: Board :: index remove the blank card and empty it when you press the escape button 1`] = `
 <main
-  className="myBoard"
+  className="my-board"
 >
-  <div
-    className="board loader"
+  <input
+    className="new-card hidden"
+    onChange={[Function]}
+    onKeyUp={[Function]}
+    placeholder="What needs to be done?"
+    value=""
+  />
+  <button
+    className="board add-card"
+    onClick={[Function]}
   >
-    We are adding a new card...
-  </div>
+    Add another card
+  </button>
+</main>
+`;
+
+exports[`Component :: Board :: index shows the blank card when you click on "Add an other card" button 1`] = `
+<main
+  className="my-board"
+>
+  <input
+    className="new-card"
+    onChange={[Function]}
+    onKeyUp={[Function]}
+    placeholder="What needs to be done?"
+    value=""
+  />
+  <button
+    className="board add-card"
+    onClick={[Function]}
+  >
+    Add another card
+  </button>
 </main>
 `;

--- a/src/Component/Board/index.js
+++ b/src/Component/Board/index.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux'
-import { toggleBlankCard, saveCard, setBlankCardTitle } from '../../Redux/State/Board'
+import { showBlankCard, saveCard, setBlankCardTitle } from '../../Redux/State/Board'
 import { compose } from 'ramda'
 import Board from './Board'
 
@@ -12,7 +12,7 @@ const mapStateToProps = state => ({
 
 // mapDispatchToProps :: (Action * -> State) -> Props
 const mapDispatchToProps = dispatch => ({
-  addCard: compose(dispatch, toggleBlankCard),
+  addCard: compose(dispatch, showBlankCard),
   saveCard: compose(dispatch, saveCard),
   setBlankCardTitle: compose(dispatch, setBlankCardTitle)
 })

--- a/src/Component/Board/index.js
+++ b/src/Component/Board/index.js
@@ -1,17 +1,20 @@
 import { connect } from 'react-redux'
-import { addCard } from '../../Redux/State/Board'
+import { toggleBlankCard, saveCard, setBlankCardTitle } from '../../Redux/State/Board'
 import { compose } from 'ramda'
 import Board from './Board'
 
 // mapStateToProps :: State -> Props
 const mapStateToProps = state => ({
   cards: state.Board.cards,
-  isLoading: state.Board.isLoading
+  isBlankCardVisible: state.Board.isBlankCardVisible,
+  cardTitle: state.Board.blankCardTitle
 })
 
 // mapDispatchToProps :: (Action * -> State) -> Props
 const mapDispatchToProps = dispatch => ({
-  addCard: compose(dispatch, addCard)
+  addCard: compose(dispatch, toggleBlankCard),
+  saveCard: compose(dispatch, saveCard),
+  setBlankCardTitle: compose(dispatch, setBlankCardTitle)
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(Board)

--- a/src/Component/Board/index.spec.js
+++ b/src/Component/Board/index.spec.js
@@ -3,7 +3,7 @@ import { createStore } from 'redux'
 import { act } from 'react-test-renderer'
 import Board from './index'
 import State from '../../Redux/State'
-import { setBlankCardTitle, saveCard, toggleBlankCard, removeBlankCard } from '../../Redux/State/Board'
+import { setBlankCardTitle, saveCard, showBlankCard, removeBlankCard } from '../../Redux/State/Board'
 import { createContainer } from '../../utils-test'
 
 describe('Component :: Board :: index', () => {
@@ -32,7 +32,7 @@ describe('Component :: Board :: index', () => {
     })
 
     act(() => {
-      store.dispatch(toggleBlankCard())
+      store.dispatch(showBlankCard())
     })
 
     expect(inspector).toMatchSnapshot()
@@ -77,6 +77,4 @@ describe('Component :: Board :: index', () => {
 
     expect(inspector).toMatchSnapshot()
   })
-
-
 })

--- a/src/Component/Board/index.spec.js
+++ b/src/Component/Board/index.spec.js
@@ -3,7 +3,7 @@ import { createStore } from 'redux'
 import { act } from 'react-test-renderer'
 import Board from './index'
 import State from '../../Redux/State'
-import { addCard, receiveCard } from '../../Redux/State/Board'
+import { setBlankCardTitle, saveCard, toggleBlankCard, removeBlankCard } from '../../Redux/State/Board'
 import { createContainer } from '../../utils-test'
 
 describe('Component :: Board :: index', () => {
@@ -19,22 +19,7 @@ describe('Component :: Board :: index', () => {
     expect(inspector).toMatchSnapshot()
   })
 
-  it('loads when a card is creating', () => {
-    const store = createStore(State, State(), undefined)
-    let inspector
-
-    act(() => {
-      inspector = createContainer(<Board />, store)
-    })
-
-    act(() => {
-      store.dispatch(addCard())
-    })
-
-    expect(inspector).toMatchSnapshot()
-  })
-
-  it('displays the cards and add "add another card button" when it is not creating any card', () => {
+  it('shows the blank card when you click on "Add an other card" button', () => {
     const store = createStore(
       State,
       State(),
@@ -47,9 +32,51 @@ describe('Component :: Board :: index', () => {
     })
 
     act(() => {
-      store.dispatch(receiveCard({ title: 'My test card' }))
+      store.dispatch(toggleBlankCard())
     })
 
     expect(inspector).toMatchSnapshot()
   })
+
+  it('displays the cards when a card is added', () => {
+    const store = createStore(
+      State,
+      State(),
+      undefined
+    )
+    let inspector
+
+    act(() => {
+      inspector = createContainer(<Board />, store)
+    })
+
+    act(() => {
+      store.dispatch(setBlankCardTitle('My card'))
+      store.dispatch(saveCard())
+    })
+
+    expect(inspector).toMatchSnapshot()
+  })
+
+  it('remove the blank card and empty it when you press the escape button', () => {
+    const store = createStore(
+      State,
+      State(),
+      undefined
+    )
+    let inspector
+
+    act(() => {
+      inspector = createContainer(<Board />, store)
+    })
+
+    act(() => {
+      store.dispatch(setBlankCardTitle('Do not save this title'))
+      store.dispatch(removeBlankCard())
+    })
+
+    expect(inspector).toMatchSnapshot()
+  })
+
+
 })

--- a/src/Epic/Board.js
+++ b/src/Epic/Board.js
@@ -1,16 +1,15 @@
-import { combineEpics, ofType } from 'redux-observable'
+import { isEscKey } from '../utils'
 import * as Board from '../Redux/State/Board'
-import { map } from 'rxjs/operators'
+import { combineEpics } from 'redux-observable'
+import { fromEvent } from 'rxjs'
+import { filter, map } from 'rxjs/operators'
 
-// addCardEpic :: Epic -> Observable Action Board.RECEIVE_CARD
-export const addCardEpic = (action$) => action$.pipe(
-  ofType(Board.ADD_CARD),
-  map(() => ({
-    title: 'My title'
-  })),
-  map(Board.receiveCard)
+// removeBlankCardOnEscEpic :: Epic -> Observable Action *
+const removeBlankCardOnEscEpic = () => fromEvent(document, 'keyup').pipe(
+  filter(isEscKey),
+  map(Board.removeBlankCard)
 )
 
 export default combineEpics(
-  addCardEpic
+  removeBlankCardOnEscEpic
 )

--- a/src/Redux/State/Board.js
+++ b/src/Redux/State/Board.js
@@ -1,36 +1,58 @@
-import { createReducer } from '../../Util'
+import { createReducer } from '../../utils'
 import { always } from 'ramda'
 
 // INITIAL_STATE :: State
 export const INITIAL_STATE = {
   cards: [],
-  isLoading: false
+  isBlankCardVisible: false,
+  blankCardTitle: ''
 }
 
-export const ADD_CARD = '@knp/Board/AddCard'
-export const RECEIVE_CARD = '@knp/Board/ReceiveCard'
+export const SAVE_CARD = '@knp/Board/SaveCard'
+export const SET_BLANK_CARD_TITLE = '@knp/Board/SetBlankCardTitle'
+export const TOGGLE_BLANK_CARD = '@knp/Board/ToggleBlankCard'
+export const REMOVE_BLANK_CARD = '@knp/Board/RemoveBlankCard'
 
-// addCard :: () -> Action ADD_CARD
-export const addCard = always({ type: ADD_CARD })
 
-// receiveCard :: () -> Action RECEIVE_CARD
-export const receiveCard = card => ({
-  type: RECEIVE_CARD,
-  card
+// saveCard :: () -> Action SAVE_CARD
+export const saveCard = always({ type: SAVE_CARD })
+
+// setBlankCardTitle :: () -> Action SET_BLANK_CARD_TITLE
+export const setBlankCardTitle = cardTitle => ({
+  type: SET_BLANK_CARD_TITLE,
+  cardTitle
 })
+
+// toggleBlankCard :: () -> Action TOGGLE_BLANK_CARD
+export const toggleBlankCard = always({ type: TOGGLE_BLANK_CARD })
+
+// removeBlankCard :: () -> Action REMOVE_BLANK_CARD
+export const removeBlankCard = always({ type: REMOVE_BLANK_CARD })
 
 // Board :: (State, Action *) -> State
 export default createReducer(INITIAL_STATE, {
-  [ADD_CARD]: state => ({
+  [SAVE_CARD]: state => ({
     ...state,
-    isLoading: true
-  }),
-  [RECEIVE_CARD]: (state, { card }) => ({
-    ...state,
-    isLoading: false,
+    blankCardTitle: '',
+    isBlankCardVisible: false,
     cards: [
       ...state.cards,
-      card
+      {
+        title: state.blankCardTitle
+      }
     ]
+  }),
+  [SET_BLANK_CARD_TITLE]: (state, { cardTitle }) => ({
+    ...state,
+    blankCardTitle: cardTitle
+  }),
+  [TOGGLE_BLANK_CARD]: state => ({
+    ...state,
+    isBlankCardVisible: true
+  }),
+  [REMOVE_BLANK_CARD]: state => ({
+    ...state,
+    isBlankCardVisible: false,
+    blankCardTitle: ''
   })
 })

--- a/src/Redux/State/Board.js
+++ b/src/Redux/State/Board.js
@@ -10,7 +10,7 @@ export const INITIAL_STATE = {
 
 export const SAVE_CARD = '@knp/Board/SaveCard'
 export const SET_BLANK_CARD_TITLE = '@knp/Board/SetBlankCardTitle'
-export const TOGGLE_BLANK_CARD = '@knp/Board/ToggleBlankCard'
+export const SHOW_BLANK_CARD = '@knp/Board/ShowBlankCard'
 export const REMOVE_BLANK_CARD = '@knp/Board/RemoveBlankCard'
 
 
@@ -23,8 +23,8 @@ export const setBlankCardTitle = cardTitle => ({
   cardTitle
 })
 
-// toggleBlankCard :: () -> Action TOGGLE_BLANK_CARD
-export const toggleBlankCard = always({ type: TOGGLE_BLANK_CARD })
+// showBlankCard :: () -> Action SHOW_BLANK_CARD
+export const showBlankCard = always({ type: SHOW_BLANK_CARD })
 
 // removeBlankCard :: () -> Action REMOVE_BLANK_CARD
 export const removeBlankCard = always({ type: REMOVE_BLANK_CARD })
@@ -46,7 +46,7 @@ export default createReducer(INITIAL_STATE, {
     ...state,
     blankCardTitle: cardTitle
   }),
-  [TOGGLE_BLANK_CARD]: state => ({
+  [SHOW_BLANK_CARD]: state => ({
     ...state,
     isBlankCardVisible: true
   }),

--- a/src/Redux/State/Board.spec.js
+++ b/src/Redux/State/Board.spec.js
@@ -1,8 +1,10 @@
 import {
-  addCard,
-  receiveCard,
+  setBlankCardTitle,
   INITIAL_STATE,
-  default as reducer
+  default as reducer,
+  toggleBlankCard,
+  saveCard,
+  removeBlankCard
 } from './Board'
 
 describe('Redux :: Module :: Board', () => {
@@ -10,25 +12,53 @@ describe('Redux :: Module :: Board', () => {
     expect(reducer()).toEqual(INITIAL_STATE)
   })
 
-  it('reduces the add card action', () => {
+  it('reduces set blank card title action', () => {
     expect(
-      reducer(INITIAL_STATE, addCard()),
+      reducer(INITIAL_STATE, setBlankCardTitle('test blank card title')),
     ).toEqual({
       ...INITIAL_STATE,
-      isLoading: true
+      blankCardTitle: 'test blank card title'
     })
   })
 
-  it('reduces receive card action', () => {
-    const s1 = reducer(INITIAL_STATE, addCard())
-    const s2 = reducer(s1, receiveCard({ title: 'My title' }))
+  it('reduces toggle blank card action', () => {
+    expect(
+      reducer(INITIAL_STATE, toggleBlankCard()),
+    ).toEqual({
+      ...INITIAL_STATE,
+      isBlankCardVisible: true
+    })
+  })
 
-    expect(s2).toEqual({
+  it('reduces save card action', () => {
+    const s1 = reducer(INITIAL_STATE, setBlankCardTitle('test other title'))
+
+    expect(s1).toEqual({
+      ...INITIAL_STATE,
+      blankCardTitle: 'test other title'
+    })
+
+    expect(
+      reducer(s1, saveCard()),
+    ).toEqual({
       ...s1,
-      cards: [{
-        title: 'My title'
-      }],
-      isLoading: false
+      blankCardTitle: '',
+      isBlankCardVisible: false,
+      cards: [
+        {
+          title: 'test other title'
+        }
+      ]
+    })
+  })
+
+  it('reduces remove blank card action', () => {
+    expect(
+      reducer(INITIAL_STATE, removeBlankCard()),
+    ).toEqual({
+      ...INITIAL_STATE,
+      isBlankCardVisible: false,
+      blankCardTitle: ''
     })
   })
 })

--- a/src/Redux/State/Board.spec.js
+++ b/src/Redux/State/Board.spec.js
@@ -2,7 +2,7 @@ import {
   setBlankCardTitle,
   INITIAL_STATE,
   default as reducer,
-  toggleBlankCard,
+  showBlankCard,
   saveCard,
   removeBlankCard
 } from './Board'
@@ -21,9 +21,9 @@ describe('Redux :: Module :: Board', () => {
     })
   })
 
-  it('reduces toggle blank card action', () => {
+  it('reduces show blank card action', () => {
     expect(
-      reducer(INITIAL_STATE, toggleBlankCard()),
+      reducer(INITIAL_STATE, showBlankCard()),
     ).toEqual({
       ...INITIAL_STATE,
       isBlankCardVisible: true
@@ -53,12 +53,11 @@ describe('Redux :: Module :: Board', () => {
   })
 
   it('reduces remove blank card action', () => {
+    const s1 = reducer(INITIAL_STATE, showBlankCard())
+    const s2 = reducer(s1, setBlankCardTitle('do not save this title title'))
+
     expect(
-      reducer(INITIAL_STATE, removeBlankCard()),
-    ).toEqual({
-      ...INITIAL_STATE,
-      isBlankCardVisible: false,
-      blankCardTitle: ''
-    })
+      reducer(s2, removeBlankCard()),
+    ).toEqual(INITIAL_STATE)
   })
 })

--- a/src/Style/Main.scss
+++ b/src/Style/Main.scss
@@ -12,6 +12,12 @@ main {
     margin: auto;
   }
 
+  .new-card {
+    padding: 2px 5px;
+    display: block;
+    margin: 10px auto;
+  }
+
   .card {
     width: 200px;
     min-height: 100px;
@@ -23,6 +29,10 @@ main {
     h3 {
       font-size: 22px;
     }
+  }
+
+  .hidden {
+    opacity: 0;
   }
 
   button {

--- a/src/Util.js
+++ b/src/Util.js
@@ -1,6 +1,0 @@
-import { propOr, identity, prop } from 'ramda'
-
-// createReducer :: (State, Object) -> (State, Action) -> State
-export const createReducer = (initialState, handlers) =>
-  (state = initialState, action = {}) =>
-    propOr(identity, prop('type', action), handlers)(state, action)

--- a/src/index.js
+++ b/src/index.js
@@ -8,19 +8,15 @@ import { createEpicMiddleware } from 'redux-observable'
 import rootEpic from './Epic'
 import { default as mainReducer, debug } from './Redux/State'
 
-const epicMiddleware = createEpicMiddleware({
-  dependencies: {
-    fetchDog: () => fetch('https://dog.ceo/api/breeds/image/random'),
-  },
-});
-const middleware     = applyMiddleware(epicMiddleware);
-const reducer        = Number(process.env.REACT_APP_DEBUG_STATE)
+const epicMiddleware = createEpicMiddleware({})
+const middleware = applyMiddleware(epicMiddleware)
+const reducer = Number(process.env.REACT_APP_DEBUG_STATE)
   ? debug(mainReducer)
-  : mainReducer;
-const store          = createStore(reducer, reducer(), middleware);
+  : mainReducer
+const store = createStore(reducer, reducer(), middleware)
 
-epicMiddleware.run(rootEpic);
+epicMiddleware.run(rootEpic)
 
-ReactDOM.render(<App store={store} />, document.getElementById('root'));
+ReactDOM.render(<App store={store} />, document.getElementById('root'))
 
 registerServiceWorker();

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,15 @@
+import { propOr, identity, prop, compose, equals, toLower } from 'ramda'
+
+// createReducer :: (State, Object) -> (State, Action) -> State
+export const createReducer = (initialState, handlers) =>
+  (state = initialState, action = {}) =>
+    propOr(identity, prop('type', action), handlers)(state, action)
+
+// isKey :: String -> KeyboardEvent -> Boolean
+const isKey = keyCode => compose(equals(keyCode), toLower, propOr('', 'key'))
+
+// isEscKey :: KeyboardEvent -> Boolean
+export const isEscKey = isKey('escape')
+
+// isReturnKey :: KeyboardEvent -> Boolean
+export const isReturnKey = isKey('13')


### PR DESCRIPTION
**Guideline** : [knptaste-react-guidelines.md](https://github.com/KnpLabs/knowledge/blob/master/projects/)

**Scenarios** : 

- [x] As a regular user, when I click on "Add another card", then a new empty card should be created and focused so I can enter the title of the card.
- [x] As a regular user, given I've clicked on "Add another card" and written some text in it, when I press "return", then the new card should be created.
- [x] As a regular user, given I've clicked on "Add another card" and I pressed the "escape" key, then the new card should be removed.
- [ ] As a regular user, when I click on the little remove button over an existing card, then I should see a confirmation message.
- [ ] As a regular user, given I've clicked on the remove button over an existing card and I clicked on "ok", then the card should be removed.